### PR TITLE
Simplify types for one system

### DIFF
--- a/src/engine/DependentSystem.hpp
+++ b/src/engine/DependentSystem.hpp
@@ -7,8 +7,8 @@
 
 struct ISystem {
 	virtual const std::string_view name() = 0;
-	virtual constexpr std::unordered_set<std::type_index> reads() = 0;
-	virtual constexpr std::unordered_set<std::type_index> writes() = 0;
+	virtual const std::unordered_set<std::type_index> reads() = 0;
+	virtual const std::unordered_set<std::type_index> writes() = 0;
 	// Tagged Maybe
 	// Writes for next Frame
 	virtual void update(entt::registry &registry, float delta) const = 0;
@@ -34,12 +34,12 @@ struct System<Self, Reads<Read...>, Writes<Write...>, Others<Other...>> : virtua
 		return std::string_view(name.begin() + 6, name.end());
 	}
 
-	virtual constexpr std::unordered_set<std::type_index> reads() {
+	virtual const std::unordered_set<std::type_index> reads() {
 		static auto set = std::unordered_set<std::type_index>{typeid(Read)...};
 		return set;
 	}
 
-	virtual constexpr std::unordered_set<std::type_index> writes() {
+	virtual const std::unordered_set<std::type_index> writes() {
 		static auto set = std::unordered_set<std::type_index>{typeid(Write)...};
 		return set;
 	}

--- a/src/engine/systems/ControllerSystem.cpp
+++ b/src/engine/systems/ControllerSystem.cpp
@@ -4,83 +4,99 @@
 
 #include "../Components.hpp"
 
-void ControllerSystem::update(entt::registry &registry, float delta, entt::entity ent, GamepadInput &input) const {
-	// Get Joystick Input
-	auto joystickId = input.joystickId;
-	if (glfwJoystickPresent(joystickId) != GLFW_TRUE) {
-		input.timeSinceLastSeen += delta;
+const std::string_view ControllerSystem::name() {
+	return "ControllerSystem";
+}
 
-		// If we haven't seen the controller for 10 seconds, assume it's disconnected
-		if (input.timeSinceLastSeen > 10.f) {
-			input.connected = false;
+const std::unordered_set<std::type_index> ControllerSystem::reads() {
+	static auto set = std::unordered_set<std::type_index>{};
+	return set;
+}
+
+const std::unordered_set<std::type_index> ControllerSystem::writes() {
+	static auto set = std::unordered_set<std::type_index>{typeid(GamepadInput)};
+	return set;
+}
+
+void ControllerSystem::update(entt::registry &registry, float delta) const {
+	registry.view<GamepadInput>().each([this, &registry, delta](entt::entity ent, GamepadInput input) {
+		// Get Joystick Input
+		auto joystickId = input.joystickId;
+		if (glfwJoystickPresent(joystickId) != GLFW_TRUE) {
+			input.timeSinceLastSeen += delta;
+
+			// If we haven't seen the controller for 10 seconds, assume it's disconnected
+			if (input.timeSinceLastSeen > 10.f) {
+				input.connected = false;
+			}
+			return;
 		}
-		return;
-	}
-	int axesCount;
-	auto axes = glfwGetJoystickAxes(joystickId, &axesCount);
-	int buttonsCount;
-	auto buttons = glfwGetJoystickButtons(joystickId, &buttonsCount);
-	if (axesCount < GLFW_GAMEPAD_AXIS_LAST || buttonsCount < GLFW_GAMEPAD_BUTTON_LAST) {
-		return;  // Not a valid controller
-	}
+		int axesCount;
+		auto axes = glfwGetJoystickAxes(joystickId, &axesCount);
+		int buttonsCount;
+		auto buttons = glfwGetJoystickButtons(joystickId, &buttonsCount);
+		if (axesCount < GLFW_GAMEPAD_AXIS_LAST || buttonsCount < GLFW_GAMEPAD_BUTTON_LAST) {
+			return;  // Not a valid controller
+		}
 
-	// left stick
-	float x = axes[GLFW_GAMEPAD_AXIS_LEFT_X];
-	float y = axes[GLFW_GAMEPAD_AXIS_LEFT_Y];
-	float deadzone = 0.2f;
-	if (x < -deadzone || x > deadzone) {
-		input.leftStick.x = 0.f;
-	}
-	if (y < -deadzone || y > deadzone) {
-		input.leftStick.y = 0.f;
-	}
-	input.leftStick.x = x;
-	input.leftStick.y = y;
+		// left stick
+		float x = axes[GLFW_GAMEPAD_AXIS_LEFT_X];
+		float y = axes[GLFW_GAMEPAD_AXIS_LEFT_Y];
+		float deadzone = 0.2f;
+		if (x < -deadzone || x > deadzone) {
+			input.leftStick.x = 0.f;
+		}
+		if (y < -deadzone || y > deadzone) {
+			input.leftStick.y = 0.f;
+		}
+		input.leftStick.x = x;
+		input.leftStick.y = y;
 
-	// right stick
-	x = axes[GLFW_GAMEPAD_AXIS_RIGHT_X];
-	y = axes[GLFW_GAMEPAD_AXIS_RIGHT_Y];
-	if (x < -deadzone || x > deadzone) {
-		input.rightStick.x = 0.f;
-	}
-	if (y < -deadzone || y > deadzone) {
-		input.rightStick.y = 0.f;
-	}
-	input.rightStick.x = x;
-	input.rightStick.y = y;
+		// right stick
+		x = axes[GLFW_GAMEPAD_AXIS_RIGHT_X];
+		y = axes[GLFW_GAMEPAD_AXIS_RIGHT_Y];
+		if (x < -deadzone || x > deadzone) {
+			input.rightStick.x = 0.f;
+		}
+		if (y < -deadzone || y > deadzone) {
+			input.rightStick.y = 0.f;
+		}
+		input.rightStick.x = x;
+		input.rightStick.y = y;
 
-	// left trigger
-	float leftTrigger = axes[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER];
-	// remap from [-1, 1] to [0, 1]
-	leftTrigger = (leftTrigger + 1.f) / 2.f;
-	if (leftTrigger < deadzone) {
-		input.leftTrigger = 0.f;
-	}
-	input.leftTrigger = leftTrigger;
+		// left trigger
+		float leftTrigger = axes[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER];
+		// remap from [-1, 1] to [0, 1]
+		leftTrigger = (leftTrigger + 1.f) / 2.f;
+		if (leftTrigger < deadzone) {
+			input.leftTrigger = 0.f;
+		}
+		input.leftTrigger = leftTrigger;
 
-	// right trigger
-	float rightTrigger = axes[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER];
-	// remap from [-1, 1] to [0, 1]
-	rightTrigger = (rightTrigger + 1.f) / 2.f;
-	if (rightTrigger < deadzone) {
-		input.rightTrigger = 0.f;
-	}
-	input.rightTrigger = rightTrigger;
+		// right trigger
+		float rightTrigger = axes[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER];
+		// remap from [-1, 1] to [0, 1]
+		rightTrigger = (rightTrigger + 1.f) / 2.f;
+		if (rightTrigger < deadzone) {
+			input.rightTrigger = 0.f;
+		}
+		input.rightTrigger = rightTrigger;
 
-	// buttons
-	input.a = buttons[GLFW_GAMEPAD_BUTTON_A] == GLFW_PRESS;
-	input.b = buttons[GLFW_GAMEPAD_BUTTON_B] == GLFW_PRESS;
-	input.x = buttons[GLFW_GAMEPAD_BUTTON_X] == GLFW_PRESS;
-	input.y = buttons[GLFW_GAMEPAD_BUTTON_Y] == GLFW_PRESS;
-	input.leftBumper = buttons[GLFW_GAMEPAD_BUTTON_LEFT_BUMPER] == GLFW_PRESS;
-	input.rightBumper = buttons[GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER] == GLFW_PRESS;
-	input.up = buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] == GLFW_PRESS;
-	input.down = buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] == GLFW_PRESS;
-	input.left = buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] == GLFW_PRESS;
-	input.right = buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] == GLFW_PRESS;
-	input.leftStickButton = buttons[GLFW_GAMEPAD_BUTTON_LEFT_THUMB] == GLFW_PRESS;
-	input.rightStickButton = buttons[GLFW_GAMEPAD_BUTTON_RIGHT_THUMB] == GLFW_PRESS;
-	input.start = buttons[GLFW_GAMEPAD_BUTTON_START] == GLFW_PRESS;
-	input.back = buttons[GLFW_GAMEPAD_BUTTON_BACK] == GLFW_PRESS;
-	input.guide = buttons[GLFW_GAMEPAD_BUTTON_GUIDE] == GLFW_PRESS;
+		// buttons
+		input.a = buttons[GLFW_GAMEPAD_BUTTON_A] == GLFW_PRESS;
+		input.b = buttons[GLFW_GAMEPAD_BUTTON_B] == GLFW_PRESS;
+		input.x = buttons[GLFW_GAMEPAD_BUTTON_X] == GLFW_PRESS;
+		input.y = buttons[GLFW_GAMEPAD_BUTTON_Y] == GLFW_PRESS;
+		input.leftBumper = buttons[GLFW_GAMEPAD_BUTTON_LEFT_BUMPER] == GLFW_PRESS;
+		input.rightBumper = buttons[GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER] == GLFW_PRESS;
+		input.up = buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] == GLFW_PRESS;
+		input.down = buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] == GLFW_PRESS;
+		input.left = buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] == GLFW_PRESS;
+		input.right = buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] == GLFW_PRESS;
+		input.leftStickButton = buttons[GLFW_GAMEPAD_BUTTON_LEFT_THUMB] == GLFW_PRESS;
+		input.rightStickButton = buttons[GLFW_GAMEPAD_BUTTON_RIGHT_THUMB] == GLFW_PRESS;
+		input.start = buttons[GLFW_GAMEPAD_BUTTON_START] == GLFW_PRESS;
+		input.back = buttons[GLFW_GAMEPAD_BUTTON_BACK] == GLFW_PRESS;
+		input.guide = buttons[GLFW_GAMEPAD_BUTTON_GUIDE] == GLFW_PRESS;
+	});
 }

--- a/src/engine/systems/ControllerSystem.hpp
+++ b/src/engine/systems/ControllerSystem.hpp
@@ -2,6 +2,9 @@
 #include "../Components.hpp"
 #include "../DependentSystem.hpp"
 
-struct ControllerSystem : WSystem<ControllerSystem, Writes<GamepadInput>> {
-	void update(entt::registry &registry, float delta, entt::entity ent, GamepadInput &input) const;
+struct ControllerSystem : public ISystem {
+	const std::string_view name();
+	const std::unordered_set<std::type_index> reads();
+	const std::unordered_set<std::type_index> writes();
+	void update(entt::registry &registry, float delta) const;
 };


### PR DESCRIPTION
Changes to use the ISystem directly instead of the Type Dependent System, which had the intention of keeping track what is written/read from in a system. Doing this would allow type system guarenteed multithreading.
This draft is merely an example of a single system converted to using manual booking keeping of read/writes.

Pros:
- Faster Compile, the templates seems to take a significant time to compile.
- Simplere to expand, i for example want to add stuff like creates/delete entities and writes to a component for next frame.

Cons:
- Keeping track of what components is written and read is the responsible of the developer. Which may lead to race conditions when multithreading is introduced. 